### PR TITLE
[HOTFIX] Add healthcheck for database to ensure API waits until DB is ready

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,9 @@ services:
 #      - ./.env
     ports:
       - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
 
   db:
     image: postgres:15
@@ -31,6 +34,11 @@ services:
       - POSTGRES_DB=receiver_app
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d receiver_app"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Ao iniciar a aplicação do zero (sem ter iniciado anteriormente), estava ocorrendo um erro de conexão com o Banco de Dados. Dado isso, foi adicionado um `healthcheck` no serviço do DB do _compose_, onde a API aguarda o DB estar pronto para conexões, assim evitando erros.